### PR TITLE
Update to Node 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ jobs:
 
       - name: Set MyProject.csproj version
         id: update
-        uses: vers-one/dotnet-project-version-updater@v1.3
+        uses: vers-one/dotnet-project-version-updater@v1.4
         with:
           file: "src/MyProject.csproj"
           version: ${{ github.event.inputs.version }}
@@ -159,7 +159,7 @@ jobs:
 
       - name: Set project versions
         id: update
-        uses: vers-one/dotnet-project-version-updater@v1.3
+        uses: vers-one/dotnet-project-version-updater@v1.4
         with:
           file: |
             "**/*.csproj", "**/*.nuspec", "**/AssemblyInfo.cs"
@@ -203,7 +203,7 @@ jobs:
 
       - name: Bump build version
         id: bump
-        uses: vers-one/dotnet-project-version-updater@v1.3
+        uses: vers-one/dotnet-project-version-updater@v1.4
         with:
           file: "src/MyProject.csproj"
           version: bump-build

--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ outputs:
   newVersion:
     description: "Version set by the action during the update"
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-project-version-updater",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A GitHub action to update or bump project versions. Supports .csproj, .props, .nuspec, and many other .NET file types.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Node.js 16 is [being deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) for GitHub Actions. This pull request updates the version of Node.js used by this action to 20.