### PR TITLE
Add VersionPrefix support to csproj, vbproj, fsproj, and props files

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,10 +219,13 @@ jobs:
 ## Additional notes
 
 * This action searches for the following version declarations:
-  * for .csproj, .vbproj, .fsproj, .props, and .nuspec files:
+  * for .csproj, .vbproj, .fsproj and .props files:
     * `<Version>...</Version>`;
+    * `<VersionPrefix>...</VersionPrefix>`;
     * `<AssemblyVersion>...</AssemblyVersion>`;
     * `<FileVersion>...</FileVersion>`;
+  * for .nuspec files:
+    * `<Version>...</Version>`;
   * for .cs files:
     * `[assembly: AssemblyVersion("...")]`;
     * `[assembly: AssemblyFileVersion("...")]`;

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ jobs:
 ## Additional notes
 
 * This action searches for the following version declarations:
-  * for .csproj, .vbproj, .fsproj and .props files:
+  * for .csproj, .vbproj, .fsproj, and .props files:
     * `<Version>...</Version>`;
     * `<VersionPrefix>...</VersionPrefix>`;
     * `<AssemblyVersion>...</AssemblyVersion>`;

--- a/src/plugins/csproj-plugin.ts
+++ b/src/plugins/csproj-plugin.ts
@@ -1,6 +1,7 @@
 import Plugin, { PluginVersionRegex, VersionPartDelimiter } from "./plugin";
 
 const VERSION_TAG_REGEX: RegExp = /<Version>(.*)<\/Version>/i;
+const VERSION_PREFIX_TAG_REGEX: RegExp = /<VersionPrefix>(.*)<\/VersionPrefix>/i;
 const ASSEMBLY_VERSION_TAG_REGEX: RegExp = /<AssemblyVersion>(.*)<\/AssemblyVersion>/i;
 const FILE_VERSION_TAG_REGEX: RegExp = /<FileVersion>(.*)<\/FileVersion>/i;
 
@@ -14,6 +15,11 @@ export default class CsProjPlugin extends Plugin
                 regex: VERSION_TAG_REGEX,
                 versionPartDelimiter: VersionPartDelimiter.DOT,
                 versionType: "<Version> tag"
+            },
+            {
+                regex: VERSION_PREFIX_TAG_REGEX,
+                versionPartDelimiter: VersionPartDelimiter.DOT,
+                versionType: "<VersionPrefix> tag"
             },
             {
                 regex: ASSEMBLY_VERSION_TAG_REGEX,

--- a/src/plugins/fsproj-plugin.ts
+++ b/src/plugins/fsproj-plugin.ts
@@ -1,6 +1,7 @@
 import Plugin, { PluginVersionRegex, VersionPartDelimiter } from "./plugin";
 
 const VERSION_TAG_REGEX: RegExp = /<Version>(.*)<\/Version>/i;
+const VERSION_PREFIX_TAG_REGEX: RegExp = /<VersionPrefix>(.*)<\/VersionPrefix>/i;
 const ASSEMBLY_VERSION_TAG_REGEX: RegExp = /<AssemblyVersion>(.*)<\/AssemblyVersion>/i;
 const FILE_VERSION_TAG_REGEX: RegExp = /<FileVersion>(.*)<\/FileVersion>/i;
 
@@ -14,6 +15,11 @@ export default class FsProjPlugin extends Plugin
                 regex: VERSION_TAG_REGEX,
                 versionPartDelimiter: VersionPartDelimiter.DOT,
                 versionType: "<Version> tag"
+            },
+            {
+                regex: VERSION_PREFIX_TAG_REGEX,
+                versionPartDelimiter: VersionPartDelimiter.DOT,
+                versionType: "<VersionPrefix> tag"
             },
             {
                 regex: ASSEMBLY_VERSION_TAG_REGEX,

--- a/src/plugins/props-plugin.ts
+++ b/src/plugins/props-plugin.ts
@@ -1,6 +1,7 @@
 import Plugin, { PluginVersionRegex, VersionPartDelimiter } from "./plugin";
 
 const VERSION_TAG_REGEX: RegExp = /<Version>(.*)<\/Version>/i;
+const VERSION_PREFIX_TAG_REGEX: RegExp = /<VersionPrefix>(.*)<\/VersionPrefix>/i;
 const ASSEMBLY_VERSION_TAG_REGEX: RegExp = /<AssemblyVersion>(.*)<\/AssemblyVersion>/i;
 const FILE_VERSION_TAG_REGEX: RegExp = /<FileVersion>(.*)<\/FileVersion>/i;
 
@@ -14,6 +15,11 @@ export default class PropsPlugin extends Plugin
                 regex: VERSION_TAG_REGEX,
                 versionPartDelimiter: VersionPartDelimiter.DOT,
                 versionType: "<Version> tag"
+            },
+            {
+                regex: VERSION_PREFIX_TAG_REGEX,
+                versionPartDelimiter: VersionPartDelimiter.DOT,
+                versionType: "<VersionPrefix> tag"
             },
             {
                 regex: ASSEMBLY_VERSION_TAG_REGEX,

--- a/src/plugins/vbproj-plugin.ts
+++ b/src/plugins/vbproj-plugin.ts
@@ -1,6 +1,7 @@
 import Plugin, { PluginVersionRegex, VersionPartDelimiter } from "./plugin";
 
 const VERSION_TAG_REGEX: RegExp = /<Version>(.*)<\/Version>/i;
+const VERSION_PREFIX_TAG_REGEX: RegExp = /<VersionPrefix>(.*)<\/VersionPrefix>/i;
 const ASSEMBLY_VERSION_TAG_REGEX: RegExp = /<AssemblyVersion>(.*)<\/AssemblyVersion>/i;
 const FILE_VERSION_TAG_REGEX: RegExp = /<FileVersion>(.*)<\/FileVersion>/i;
 
@@ -15,6 +16,11 @@ export default class VbProjPlugin extends Plugin
                 versionPartDelimiter: VersionPartDelimiter.DOT,
                 versionType: "<Version> tag"
             },
+            {
+                regex: VERSION_PREFIX_TAG_REGEX,
+                versionPartDelimiter: VersionPartDelimiter.DOT,
+                versionType: "<VersionPrefix> tag"
+            }, 
             {
                 regex: ASSEMBLY_VERSION_TAG_REGEX,
                 versionPartDelimiter: VersionPartDelimiter.DOT,

--- a/test-files/expected-results/Test.csproj
+++ b/test-files/expected-results/Test.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Version>4.5.6</Version>
+        <VersionPrefix>4.5.6</VersionPrefix>
         <AssemblyVersion>4.5.6</AssemblyVersion>
         <FileVersion>4.5.6</FileVersion>
     </PropertyGroup>

--- a/test-files/expected-results/Test.fsproj
+++ b/test-files/expected-results/Test.fsproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Version>4.5.6</Version>
+        <VersionPrefix>4.5.6</VersionPrefix>
         <AssemblyVersion>4.5.6</AssemblyVersion>
         <FileVersion>4.5.6</FileVersion>
     </PropertyGroup>

--- a/test-files/expected-results/Test.props
+++ b/test-files/expected-results/Test.props
@@ -1,5 +1,6 @@
 <Project>
     <PropertyGroup>
         <Version>4.5.6</Version>
+        <VersionPrefix>4.5.6</VersionPrefix>
     </PropertyGroup>
 </Project>

--- a/test-files/expected-results/Test.vbproj
+++ b/test-files/expected-results/Test.vbproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Version>4.5.6</Version>
+        <VersionPrefix>4.5.6</VersionPrefix>
         <AssemblyVersion>4.5.6</AssemblyVersion>
         <FileVersion>4.5.6</FileVersion>
     </PropertyGroup>

--- a/test-files/input/Test.csproj
+++ b/test-files/input/Test.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Version>1.2.3</Version>
+        <VersionPrefix>1.2.3</VersionPrefix>
         <AssemblyVersion>1.2.3</AssemblyVersion>
         <FileVersion>1.2.3</FileVersion>
     </PropertyGroup>

--- a/test-files/input/Test.fsproj
+++ b/test-files/input/Test.fsproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Version>1.2.3</Version>
+        <VersionPrefix>1.2.3</VersionPrefix>
         <AssemblyVersion>1.2.3</AssemblyVersion>
         <FileVersion>1.2.3</FileVersion>
     </PropertyGroup>

--- a/test-files/input/Test.props
+++ b/test-files/input/Test.props
@@ -1,5 +1,6 @@
 <Project>
     <PropertyGroup>
         <Version>1.2.3</Version>
+        <VersionPrefix>1.2.3</VersionPrefix>
     </PropertyGroup>
 </Project>

--- a/test-files/input/Test.vbproj
+++ b/test-files/input/Test.vbproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Version>1.2.3</Version>
+        <VersionPrefix>1.2.3</VersionPrefix>
         <AssemblyVersion>1.2.3</AssemblyVersion>
         <FileVersion>1.2.3</FileVersion>
     </PropertyGroup>


### PR DESCRIPTION
In *.csproj and *.props files, by default, Version is composed of VersionPrefix and VersionSuffix, and only VersionPrefix, if VersionSuffix is blank.

Andrew Lock explain this very well in this blog post : [Version vs VersionSuffix vs PackageVersion: What do they all mean?](https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/#version)

I only added support for VersionPrefix for those file type because I know they exist and are used, not so sure for other supported files.

Tests for those 2 file types are updated.

I did not find any contribution directives, so I went for the obvious edits but if something is missing, I'll be happy to comply :)