### PR TITLE
InformationalVersion tag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,48 +94,56 @@ Allows to refine the `file` / `files` filter to exclude the unwanted version dec
 
 Supported tags:
 
-|Tag                                   |Description                                                                   |
-|--------------------------------------|------------------------------------------------------------------------------|
-|`*`                                   |Process all supported version declarations in all supported file types        |
-|`csproj.*`                            |Process all supported version declarations in *.csproj* files                 |
-|`csproj.Version`                      |Process `<Version>...</Version>` item in *.csproj* files                      |
-|`csproj.VersionPrefix`                |Process `<VersionPrefix>...</VersionPrefix>` item in *.csproj* files          |
-|`csproj.AssemblyVersion`              |Process `<AssemblyVersion>...</AssemblyVersion>` item in *.csproj* files      |
-|`csproj.FileVersion`                  |Process `<FileVersion>...</FileVersion>` item in *.csproj* files              |
-|`vbproj.*`                            |Process all supported version declarations in *.vbproj* files                 |
-|`vbproj.Version`                      |Process `<Version>...</Version>` item in *.vbproj* files                      |
-|`vbproj.VersionPrefix`                |Process `<VersionPrefix>...</VersionPrefix>` item in *.vbproj* files          |
-|`vbproj.AssemblyVersion`              |Process `<AssemblyVersion>...</AssemblyVersion>` item in *.vbproj* files      |
-|`vbproj.FileVersion`                  |Process `<FileVersion>...</FileVersion>` item in *.vbproj* files              |
-|`fsproj.*`                            |Process all supported version declarations in *.fsproj* files                 |
-|`fsproj.Version`                      |Process `<Version>...</Version>` item in *.fsproj* files                      |
-|`fsproj.VersionPrefix`                |Process `<VersionPrefix>...</VersionPrefix>` item in *.fsproj* files          |
-|`fsproj.AssemblyVersion`              |Process `<AssemblyVersion>...</AssemblyVersion>` item in *.fsproj* files      |
-|`fsproj.FileVersion`                  |Process `<FileVersion>...</FileVersion>` item in *.fsproj* files              |
-|`props.*`                             |Process all supported version declarations in *.props* files                  |
-|`props.Version`                       |Process `<Version>...</Version>` item in *.props* files                       |
-|`props.VersionPrefix`                 |Process `<VersionPrefix>...</VersionPrefix>` item in *.props* files           |
-|`props.AssemblyVersion`               |Process `<AssemblyVersion>...</AssemblyVersion>` item in *.props* files       |
-|`props.FileVersion`                   |Process `<FileVersion>...</FileVersion>` item in *.props* files               |
-|`nuspec.*`                            |Process all supported version declarations in *.nuspec* files                 |
-|`nuspec.Version`                      |Process `<Version>...</Version>` item in *.nuspec* files                      |
-|`AssemblyInfo-cs.*`                   |Process all supported version declarations in *.cs* files                     |
-|`AssemblyInfo-cs.AssemblyVersion`     |Process `[assembly: AssemblyVersion("...")]` item in *.cs* files              |
-|`AssemblyInfo-cs.AssemblyFileVersion` |Process `[assembly: AssemblyFileVersion("...")]` item in *.cs* files          |
-|`AssemblyInfo-vb.*`                   |Process all supported version declarations in *.vb* files                     |
-|`AssemblyInfo-vb.AssemblyVersion`     |Process `<Assembly: AssemblyVersion("...")>` item in *.vb* files              |
-|`AssemblyInfo-vb.AssemblyFileVersion` |Process `<Assembly: AssemblyFileVersion("...")>` item in *.vb* files          |
-|`AssemblyInfo-fs.*`                   |Process all supported version declarations in *.fs* files                     |
-|`AssemblyInfo-fs.AssemblyVersion`     |Process `[<assembly: AssemblyVersion("...")>]` item in *.fs* files            |
-|`AssemblyInfo-fs.AssemblyFileVersion` |Process `[<assembly: AssemblyFileVersion("...")>]` item in *.fs* files        |
-|`AssemblyInfo-cpp.*`                  |Process all supported version declarations in *.cpp* files                    |
-|`AssemblyInfo-cpp.AssemblyVersion`    |Process `[assembly:AssemblyVersionAttribute(L"...")]` item in *.cpp* files    |
-|`AssemblyInfo-cpp.AssemblyFileVersion`|Process `[assembly:AssemblyFileVersionAttribute(L"...")]` item in *.cpp* files|
-|`rc.*`                                |Process all supported version declarations in *.rc* files                     |
-|`rc.FileVersion-param`                |Process `FILEVERSION x,x,x,x` item in *.rc* files                             |
-|`rc.ProductVersion-param`             |Process `PRODUCTVERSION x,x,x,x` item in *.rc* files                          |
-|`rc.FileVersion-string`               |Process `VALUE "FileVersion", "..."` item in *.rc* files                      |
-|`rc.ProductVersion-string`            |Process `VALUE "ProductVersion", "..."` item in *.rc* files                   |
+|Tag                                            |Description                                                                            |
+|-----------------------------------------------|---------------------------------------------------------------------------------------|
+|`*`                                            |Process all supported version declarations in all supported file types                 |
+|`csproj.*`                                     |Process all supported version declarations in *.csproj* files                          |
+|`csproj.Version`                               |Process `<Version>...</Version>` item in *.csproj* files                               |
+|`csproj.VersionPrefix`                         |Process `<VersionPrefix>...</VersionPrefix>` item in *.csproj* files                   |
+|`csproj.AssemblyVersion`                       |Process `<AssemblyVersion>...</AssemblyVersion>` item in *.csproj* files               |
+|`csproj.FileVersion`                           |Process `<FileVersion>...</FileVersion>` item in *.csproj* files                       |
+|`csproj.InformationalVersion`                  |Process `<InformationalVersion>...</InformationalVersion>` item in *.csproj* files     |
+|`vbproj.*`                                     |Process all supported version declarations in *.vbproj* files                          |
+|`vbproj.Version`                               |Process `<Version>...</Version>` item in *.vbproj* files                               |
+|`vbproj.VersionPrefix`                         |Process `<VersionPrefix>...</VersionPrefix>` item in *.vbproj* files                   |
+|`vbproj.AssemblyVersion`                       |Process `<AssemblyVersion>...</AssemblyVersion>` item in *.vbproj* files               |
+|`vbproj.FileVersion`                           |Process `<FileVersion>...</FileVersion>` item in *.vbproj* files                       |
+|`vbproj.InformationalVersion`                  |Process `<InformationalVersion>...</InformationalVersion>` item in *.vbproj* files     |
+|`fsproj.*`                                     |Process all supported version declarations in *.fsproj* files                          |
+|`fsproj.Version`                               |Process `<Version>...</Version>` item in *.fsproj* files                               |
+|`fsproj.VersionPrefix`                         |Process `<VersionPrefix>...</VersionPrefix>` item in *.fsproj* files                   |
+|`fsproj.AssemblyVersion`                       |Process `<AssemblyVersion>...</AssemblyVersion>` item in *.fsproj* files               |
+|`fsproj.FileVersion`                           |Process `<FileVersion>...</FileVersion>` item in *.fsproj* files                       |
+|`fsproj.InformationalVersion`                  |Process `<InformationalVersion>...</InformationalVersion>` item in *.fsproj* files     |
+|`props.*`                                      |Process all supported version declarations in *.props* files                           |
+|`props.Version`                                |Process `<Version>...</Version>` item in *.props* files                                |
+|`props.VersionPrefix`                          |Process `<VersionPrefix>...</VersionPrefix>` item in *.props* files                    |
+|`props.AssemblyVersion`                        |Process `<AssemblyVersion>...</AssemblyVersion>` item in *.props* files                |
+|`props.FileVersion`                            |Process `<FileVersion>...</FileVersion>` item in *.props* files                        |
+|`props.InformationalVersion`                   |Process `<InformationalVersion>...</InformationalVersion>` item in *.props* files      |
+|`nuspec.*`                                     |Process all supported version declarations in *.nuspec* files                          |
+|`nuspec.Version`                               |Process `<Version>...</Version>` item in *.nuspec* files                               |
+|`AssemblyInfo-cs.*`                            |Process all supported version declarations in *.cs* files                              |
+|`AssemblyInfo-cs.AssemblyVersion`              |Process `[assembly: AssemblyVersion("...")]` item in *.cs* files                       |
+|`AssemblyInfo-cs.AssemblyFileVersion`          |Process `[assembly: AssemblyFileVersion("...")]` item in *.cs* files                   |
+|`AssemblyInfo-cs.AssemblyInformationalVersion` |Process `[assembly: AssemblyInformationalVersion("...")]` item in *.cs* files          |
+|`AssemblyInfo-vb.*`                            |Process all supported version declarations in *.vb* files                              |
+|`AssemblyInfo-vb.AssemblyVersion`              |Process `<Assembly: AssemblyVersion("...")>` item in *.vb* files                       |
+|`AssemblyInfo-vb.AssemblyFileVersion`          |Process `<Assembly: AssemblyFileVersion("...")>` item in *.vb* files                   |
+|`AssemblyInfo-vb.AssemblyInformationalVersion` |Process `<Assembly: AssemblyInformationalVersion("...")>` item in *.vb* files          |
+|`AssemblyInfo-fs.*`                            |Process all supported version declarations in *.fs* files                              |
+|`AssemblyInfo-fs.AssemblyVersion`              |Process `[<assembly: AssemblyVersion("...")>]` item in *.fs* files                     |
+|`AssemblyInfo-fs.AssemblyFileVersion`          |Process `[<assembly: AssemblyFileVersion("...")>]` item in *.fs* files                 |
+|`AssemblyInfo-fs.AssemblyInformationalVersion` |Process `[<assembly: AssemblyInformationalVersion("...")>]` item in *.fs* files        |
+|`AssemblyInfo-cpp.*`                           |Process all supported version declarations in *.cpp* files                             |
+|`AssemblyInfo-cpp.AssemblyVersion`             |Process `[assembly:AssemblyVersionAttribute(L"...")]` item in *.cpp* files             |
+|`AssemblyInfo-cpp.AssemblyFileVersion`         |Process `[assembly:AssemblyFileVersionAttribute(L"...")]` item in *.cpp* files         |
+|`AssemblyInfo-cpp.AssemblyInformationalVersion`|Process `[assembly:AssemblyInformationalVersionAttribute(L"...")]` item in *.cpp* files|
+|`rc.*`                                         |Process all supported version declarations in *.rc* files                              |
+|`rc.FileVersion-param`                         |Process `FILEVERSION x,x,x,x` item in *.rc* files                                      |
+|`rc.ProductVersion-param`                      |Process `PRODUCTVERSION x,x,x,x` item in *.rc* files                                   |
+|`rc.FileVersion-string`                        |Process `VALUE "FileVersion", "..."` item in *.rc* files                               |
+|`rc.ProductVersion-string`                     |Process `VALUE "ProductVersion", "..."` item in *.rc* files                            |
 
 Examples:
 

--- a/src/plugins/assemblyinfo-cpp-plugin.ts
+++ b/src/plugins/assemblyinfo-cpp-plugin.ts
@@ -2,6 +2,7 @@ import Plugin, { PluginTag, VersionPartDelimiter } from "./plugin";
 
 const ASSEMBLY_VERSION_ATTRIBUTE_REGEX: RegExp = /^\s*\[assembly:\s*AssemblyVersionAttribute\(\s*L"(.*)"\s*\)]/;
 const ASSEMBLY_FILE_VERSION_ATTRIBUTE_REGEX: RegExp = /^\s*\[assembly:\s*AssemblyFileVersionAttribute\(\s*L"(.*)"\s*\)]/;
+const ASSEMBLY_INFORMATIONAL_VERSION_ATTRIBUTE_REGEX: RegExp = /^\s*\[assembly:\s*AssemblyInformationalVersionAttribute\(\s*L"(.*)"\s*\)]/;
 
 export default class AssemblyInfoCppPlugin extends Plugin
 {
@@ -20,6 +21,12 @@ export default class AssemblyInfoCppPlugin extends Plugin
                 regex: ASSEMBLY_FILE_VERSION_ATTRIBUTE_REGEX,
                 versionPartDelimiter: VersionPartDelimiter.DOT,
                 versionType: "AssemblyFileVersion attribute"
+            },
+            {
+                tagName: "assemblyinformationalversion",
+                regex: ASSEMBLY_INFORMATIONAL_VERSION_ATTRIBUTE_REGEX,
+                versionPartDelimiter: VersionPartDelimiter.DOT,
+                versionType: "AssemblyInformationalVersion attribute"
             }
         ];
         super(tags);

--- a/src/plugins/assemblyinfo-cs-plugin.ts
+++ b/src/plugins/assemblyinfo-cs-plugin.ts
@@ -2,6 +2,7 @@ import Plugin, { PluginTag, VersionPartDelimiter } from "./plugin";
 
 const ASSEMBLY_VERSION_ATTRIBUTE_REGEX: RegExp = /^\s*\[assembly:\s*AssemblyVersion\(\s*"(.*)"\s*\)]/;
 const ASSEMBLY_FILE_VERSION_ATTRIBUTE_REGEX: RegExp = /^\s*\[assembly:\s*AssemblyFileVersion\(\s*"(.*)"\s*\)]/;
+const ASSEMBLY_INFORMATIONAL_VERSION_ATTRIBUTE_REGEX: RegExp = /^\s*\[assembly:\s*AssemblyInformationalVersion\(\s*"(.*)"\s*\)]/;
 
 export default class AssemblyInfoCsPlugin extends Plugin
 {
@@ -20,6 +21,12 @@ export default class AssemblyInfoCsPlugin extends Plugin
                 regex: ASSEMBLY_FILE_VERSION_ATTRIBUTE_REGEX,
                 versionPartDelimiter: VersionPartDelimiter.DOT,
                 versionType: "AssemblyFileVersion attribute"
+            },
+            {
+                tagName: "assemblyinformationalversion",
+                regex: ASSEMBLY_INFORMATIONAL_VERSION_ATTRIBUTE_REGEX,
+                versionPartDelimiter: VersionPartDelimiter.DOT,
+                versionType: "AssemblyInformationalVersion attribute"
             }
         ];
         super(tags);

--- a/src/plugins/assemblyinfo-fs-plugin.ts
+++ b/src/plugins/assemblyinfo-fs-plugin.ts
@@ -2,6 +2,7 @@ import Plugin, { PluginTag, VersionPartDelimiter } from "./plugin";
 
 const ASSEMBLY_VERSION_ATTRIBUTE_REGEX: RegExp = /^\s*\[<assembly:\s*AssemblyVersion\(\s*"(.*)"\s*\)>]/;
 const ASSEMBLY_FILE_VERSION_ATTRIBUTE_REGEX: RegExp = /^\s*\[<assembly:\s*AssemblyFileVersion\(\s*"(.*)"\s*\)>]/;
+const ASSEMBLY_INFORMATIONAL_VERSION_ATTRIBUTE_REGEX: RegExp = /^\s*\[<assembly:\s*AssemblyInformationalVersion\(\s*"(.*)"\s*\)>]/;
 
 export default class AssemblyInfoFsPlugin extends Plugin
 {
@@ -20,6 +21,12 @@ export default class AssemblyInfoFsPlugin extends Plugin
                 regex: ASSEMBLY_FILE_VERSION_ATTRIBUTE_REGEX,
                 versionPartDelimiter: VersionPartDelimiter.DOT,
                 versionType: "AssemblyFileVersion attribute"
+            },
+            {
+                tagName: "assemblyinformationalversion",
+                regex: ASSEMBLY_INFORMATIONAL_VERSION_ATTRIBUTE_REGEX,
+                versionPartDelimiter: VersionPartDelimiter.DOT,
+                versionType: "AssemblyInformationalVersion attribute"
             }
         ];
         super(tags);

--- a/src/plugins/assemblyinfo-vb-plugin.ts
+++ b/src/plugins/assemblyinfo-vb-plugin.ts
@@ -2,6 +2,7 @@ import Plugin, { PluginTag, VersionPartDelimiter } from "./plugin";
 
 const ASSEMBLY_VERSION_ATTRIBUTE_REGEX: RegExp = /^\s*<assembly:\s*AssemblyVersion\(\s*"(.*)"\s*\)>/;
 const ASSEMBLY_FILE_VERSION_ATTRIBUTE_REGEX: RegExp = /^\s*<assembly:\s*AssemblyFileVersion\(\s*"(.*)"\s*\)>/;
+const ASSEMBLY_INFORMATIONAL_VERSION_ATTRIBUTE_REGEX: RegExp = /^\s*<assembly:\s*AssemblyInformationalVersion\(\s*"(.*)"\s*\)>/;
 
 export default class AssemblyInfoVbPlugin extends Plugin
 {
@@ -20,6 +21,12 @@ export default class AssemblyInfoVbPlugin extends Plugin
                 regex: ASSEMBLY_FILE_VERSION_ATTRIBUTE_REGEX,
                 versionPartDelimiter: VersionPartDelimiter.DOT,
                 versionType: "AssemblyFileVersion attribute"
+            },
+            {
+                tagName: "assemblyinformationalversion",
+                regex: ASSEMBLY_INFORMATIONAL_VERSION_ATTRIBUTE_REGEX,
+                versionPartDelimiter: VersionPartDelimiter.DOT,
+                versionType: "AssemblyInformationalVersion attribute"
             }
         ];
         super(tags);

--- a/src/plugins/csproj-plugin.ts
+++ b/src/plugins/csproj-plugin.ts
@@ -4,6 +4,7 @@ const VERSION_TAG_REGEX: RegExp = /<Version>(.*)<\/Version>/;
 const VERSION_PREFIX_TAG_REGEX: RegExp = /<VersionPrefix>(.*)<\/VersionPrefix>/;
 const ASSEMBLY_VERSION_TAG_REGEX: RegExp = /<AssemblyVersion>(.*)<\/AssemblyVersion>/;
 const FILE_VERSION_TAG_REGEX: RegExp = /<FileVersion>(.*)<\/FileVersion>/;
+const INFORMATIONAL_VERSION_TAG_REGEX: RegExp = /<InformationalVersion>(.*)<\/InformationalVersion>/;
 
 export default class CsProjPlugin extends Plugin
 {
@@ -34,6 +35,12 @@ export default class CsProjPlugin extends Plugin
                 regex: FILE_VERSION_TAG_REGEX,
                 versionPartDelimiter: VersionPartDelimiter.DOT,
                 versionType: "<FileVersion> tag"
+            },
+            {
+                tagName: "informationalversion",
+                regex: INFORMATIONAL_VERSION_TAG_REGEX,
+                versionPartDelimiter: VersionPartDelimiter.DOT,
+                versionType: "<InformationalVersion> tag"
             }
         ];
         super(tags);

--- a/src/plugins/fsproj-plugin.ts
+++ b/src/plugins/fsproj-plugin.ts
@@ -4,6 +4,7 @@ const VERSION_TAG_REGEX: RegExp = /<Version>(.*)<\/Version>/;
 const VERSION_PREFIX_TAG_REGEX: RegExp = /<VersionPrefix>(.*)<\/VersionPrefix>/;
 const ASSEMBLY_VERSION_TAG_REGEX: RegExp = /<AssemblyVersion>(.*)<\/AssemblyVersion>/;
 const FILE_VERSION_TAG_REGEX: RegExp = /<FileVersion>(.*)<\/FileVersion>/;
+const INFORMATIONAL_VERSION_TAG_REGEX: RegExp = /<InformationalVersion>(.*)<\/InformationalVersion>/;
 
 export default class FsProjPlugin extends Plugin
 {
@@ -34,6 +35,12 @@ export default class FsProjPlugin extends Plugin
                 regex: FILE_VERSION_TAG_REGEX,
                 versionPartDelimiter: VersionPartDelimiter.DOT,
                 versionType: "<FileVersion> tag"
+            },
+            {
+                tagName: "informationalversion",
+                regex: INFORMATIONAL_VERSION_TAG_REGEX,
+                versionPartDelimiter: VersionPartDelimiter.DOT,
+                versionType: "<InformationalVersion> tag"
             }
         ];
         super(tags);

--- a/src/plugins/props-plugin.ts
+++ b/src/plugins/props-plugin.ts
@@ -4,6 +4,7 @@ const VERSION_TAG_REGEX: RegExp = /<Version>(.*)<\/Version>/;
 const VERSION_PREFIX_TAG_REGEX: RegExp = /<VersionPrefix>(.*)<\/VersionPrefix>/;
 const ASSEMBLY_VERSION_TAG_REGEX: RegExp = /<AssemblyVersion>(.*)<\/AssemblyVersion>/;
 const FILE_VERSION_TAG_REGEX: RegExp = /<FileVersion>(.*)<\/FileVersion>/;
+const INFORMATIONAL_VERSION_TAG_REGEX: RegExp = /<InformationalVersion>(.*)<\/InformationalVersion>/;
 
 export default class PropsPlugin extends Plugin
 {
@@ -34,6 +35,12 @@ export default class PropsPlugin extends Plugin
                 regex: FILE_VERSION_TAG_REGEX,
                 versionPartDelimiter: VersionPartDelimiter.DOT,
                 versionType: "<FileVersion> tag"
+            },
+            {
+                tagName: "informationalversion",
+                regex: INFORMATIONAL_VERSION_TAG_REGEX,
+                versionPartDelimiter: VersionPartDelimiter.DOT,
+                versionType: "<InformationalVersion> tag"
             }
         ];
         super(tags);

--- a/src/plugins/vbproj-plugin.ts
+++ b/src/plugins/vbproj-plugin.ts
@@ -4,6 +4,7 @@ const VERSION_TAG_REGEX: RegExp = /<Version>(.*)<\/Version>/;
 const VERSION_PREFIX_TAG_REGEX: RegExp = /<VersionPrefix>(.*)<\/VersionPrefix>/;
 const ASSEMBLY_VERSION_TAG_REGEX: RegExp = /<AssemblyVersion>(.*)<\/AssemblyVersion>/;
 const FILE_VERSION_TAG_REGEX: RegExp = /<FileVersion>(.*)<\/FileVersion>/;
+const INFORMATIONAL_VERSION_TAG_REGEX: RegExp = /<InformationalVersion>(.*)<\/InformationalVersion>/;
 
 export default class VbProjPlugin extends Plugin
 {
@@ -34,6 +35,12 @@ export default class VbProjPlugin extends Plugin
                 regex: FILE_VERSION_TAG_REGEX,
                 versionPartDelimiter: VersionPartDelimiter.DOT,
                 versionType: "<FileVersion> tag"
+            },
+            {
+                tagName: "informationalversion",
+                regex: INFORMATIONAL_VERSION_TAG_REGEX,
+                versionPartDelimiter: VersionPartDelimiter.DOT,
+                versionType: "<InformationalVersion> tag"
             }
         ];
         super(tags);

--- a/src/tests/plugins-tests/assemblyinfo-cpp-plugin-test.ts
+++ b/src/tests/plugins-tests/assemblyinfo-cpp-plugin-test.ts
@@ -4,20 +4,29 @@ import AssemblyInfoCppPlugin from "../../plugins/assemblyinfo-cpp-plugin";
 const assemblyInfoCppPluginTest: PluginTest =
 {
     plugin: new AssemblyInfoCppPlugin(),
-    input: `[assembly:AssemblyVersionAttribute(L"1.2.3")];\n[assembly:AssemblyFileVersionAttribute(L"1.2.3")]`,
+    input: `[assembly:AssemblyVersionAttribute(L"1.2.3")];\n[assembly:AssemblyFileVersionAttribute(L"1.2.3")]\n` +
+        `[assembly:AssemblyInformationalVersionAttribute(L"1.2.3")]`,
     newVersion: "4.5.6",
     tagTests:
     [{
         tag: "*",
-        expectedResult: `[assembly:AssemblyVersionAttribute(L"4.5.6")];\n[assembly:AssemblyFileVersionAttribute(L"4.5.6")]`
+        expectedResult: `[assembly:AssemblyVersionAttribute(L"4.5.6")];\n[assembly:AssemblyFileVersionAttribute(L"4.5.6")]\n` +
+            `[assembly:AssemblyInformationalVersionAttribute(L"4.5.6")]`
     },
     {
         tag: "assemblyversion",
-        expectedResult: `[assembly:AssemblyVersionAttribute(L"4.5.6")];\n[assembly:AssemblyFileVersionAttribute(L"1.2.3")]`
+        expectedResult: `[assembly:AssemblyVersionAttribute(L"4.5.6")];\n[assembly:AssemblyFileVersionAttribute(L"1.2.3")]\n` +
+            `[assembly:AssemblyInformationalVersionAttribute(L"1.2.3")]`
     },
     {
         tag: "assemblyfileversion",
-        expectedResult: `[assembly:AssemblyVersionAttribute(L"1.2.3")];\n[assembly:AssemblyFileVersionAttribute(L"4.5.6")]`
+        expectedResult: `[assembly:AssemblyVersionAttribute(L"1.2.3")];\n[assembly:AssemblyFileVersionAttribute(L"4.5.6")]\n` +
+            `[assembly:AssemblyInformationalVersionAttribute(L"1.2.3")]`
+    },
+    {
+        tag: "assemblyinformationalversion",
+        expectedResult: `[assembly:AssemblyVersionAttribute(L"1.2.3")];\n[assembly:AssemblyFileVersionAttribute(L"1.2.3")]\n` +
+            `[assembly:AssemblyInformationalVersionAttribute(L"4.5.6")]`
     }]
 };
 

--- a/src/tests/plugins-tests/assemblyinfo-cs-plugin-test.ts
+++ b/src/tests/plugins-tests/assemblyinfo-cs-plugin-test.ts
@@ -4,20 +4,28 @@ import AssemblyInfoCsPlugin from "../../plugins/assemblyinfo-cs-plugin";
 const assemblyInfoCsPluginTest: PluginTest =
 {
     plugin: new AssemblyInfoCsPlugin(),
-    input: `[assembly: AssemblyVersion("1.2.3")]\n[assembly: AssemblyFileVersion("1.2.3")]`,
+    input: `[assembly: AssemblyVersion("1.2.3")]\n[assembly: AssemblyFileVersion("1.2.3")]\n[assembly: AssemblyInformationalVersion("1.2.3")]`,
     newVersion: "4.5.6",
     tagTests:
     [{
         tag: "*",
-        expectedResult: `[assembly: AssemblyVersion("4.5.6")]\n[assembly: AssemblyFileVersion("4.5.6")]`
+        expectedResult: `[assembly: AssemblyVersion("4.5.6")]\n[assembly: AssemblyFileVersion("4.5.6")]\n` +
+            `[assembly: AssemblyInformationalVersion("4.5.6")]`
     },
     {
         tag: "assemblyversion",
-        expectedResult: `[assembly: AssemblyVersion("4.5.6")]\n[assembly: AssemblyFileVersion("1.2.3")]`
+        expectedResult: `[assembly: AssemblyVersion("4.5.6")]\n[assembly: AssemblyFileVersion("1.2.3")]\n` +
+            `[assembly: AssemblyInformationalVersion("1.2.3")]`
     },
     {
         tag: "assemblyfileversion",
-        expectedResult: `[assembly: AssemblyVersion("1.2.3")]\n[assembly: AssemblyFileVersion("4.5.6")]`
+        expectedResult: `[assembly: AssemblyVersion("1.2.3")]\n[assembly: AssemblyFileVersion("4.5.6")]\n` +
+            `[assembly: AssemblyInformationalVersion("1.2.3")]`
+    },
+    {
+        tag: "assemblyinformationalversion",
+        expectedResult: `[assembly: AssemblyVersion("1.2.3")]\n[assembly: AssemblyFileVersion("1.2.3")]\n` +
+            `[assembly: AssemblyInformationalVersion("4.5.6")]`
     }]
 };
 

--- a/src/tests/plugins-tests/assemblyinfo-fs-plugin-test.ts
+++ b/src/tests/plugins-tests/assemblyinfo-fs-plugin-test.ts
@@ -4,20 +4,29 @@ import AssemblyInfoFsPlugin from "../../plugins/assemblyinfo-fs-plugin";
 const assemblyInfoFsPluginTest: PluginTest =
 {
     plugin: new AssemblyInfoFsPlugin(),
-    input: `[<assembly: AssemblyVersion("1.2.3")>]\n[<assembly: AssemblyFileVersion("1.2.3")>]\ndo()`,
+    input: `[<assembly: AssemblyVersion("1.2.3")>]\n[<assembly: AssemblyFileVersion("1.2.3")>]\n` +
+        `[<assembly: AssemblyInformationalVersion("1.2.3")>]\ndo()`,
     newVersion: "4.5.6",
     tagTests:
     [{
         tag: "*",
-        expectedResult: `[<assembly: AssemblyVersion("4.5.6")>]\n[<assembly: AssemblyFileVersion("4.5.6")>]\ndo()`
+        expectedResult: `[<assembly: AssemblyVersion("4.5.6")>]\n[<assembly: AssemblyFileVersion("4.5.6")>]\n` +
+            `[<assembly: AssemblyInformationalVersion("4.5.6")>]\ndo()`
     },
     {
         tag: "assemblyversion",
-        expectedResult: `[<assembly: AssemblyVersion("4.5.6")>]\n[<assembly: AssemblyFileVersion("1.2.3")>]\ndo()`
+        expectedResult: `[<assembly: AssemblyVersion("4.5.6")>]\n[<assembly: AssemblyFileVersion("1.2.3")>]\n` +
+            `[<assembly: AssemblyInformationalVersion("1.2.3")>]\ndo()`
     },
     {
         tag: "assemblyfileversion",
-        expectedResult: `[<assembly: AssemblyVersion("1.2.3")>]\n[<assembly: AssemblyFileVersion("4.5.6")>]\ndo()`
+        expectedResult: `[<assembly: AssemblyVersion("1.2.3")>]\n[<assembly: AssemblyFileVersion("4.5.6")>]\n` +
+            `[<assembly: AssemblyInformationalVersion("1.2.3")>]\ndo()`
+    },
+    {
+        tag: "assemblyinformationalversion",
+        expectedResult: `[<assembly: AssemblyVersion("1.2.3")>]\n[<assembly: AssemblyFileVersion("1.2.3")>]\n` +
+            `[<assembly: AssemblyInformationalVersion("4.5.6")>]\ndo()`
     }]
 };
 

--- a/src/tests/plugins-tests/assemblyinfo-vb-plugin-test.ts
+++ b/src/tests/plugins-tests/assemblyinfo-vb-plugin-test.ts
@@ -4,20 +4,28 @@ import AssemblyInfoVbPlugin from "../../plugins/assemblyinfo-vb-plugin";
 const assemblyInfoVbPluginTest: PluginTest =
 {
     plugin: new AssemblyInfoVbPlugin(),
-    input: `<Assembly: AssemblyVersion("1.2.3")>\n<Assembly: AssemblyFileVersion("1.2.3")>`,
+    input: `<Assembly: AssemblyVersion("1.2.3")>\n<Assembly: AssemblyFileVersion("1.2.3")>\n<Assembly: AssemblyInformationalVersion("1.2.3")>`,
     newVersion: "4.5.6",
     tagTests:
     [{
         tag: "*",
-        expectedResult: `<Assembly: AssemblyVersion("4.5.6")>\n<Assembly: AssemblyFileVersion("4.5.6")>`
+        expectedResult: `<Assembly: AssemblyVersion("4.5.6")>\n<Assembly: AssemblyFileVersion("4.5.6")>\n` +
+            `<Assembly: AssemblyInformationalVersion("4.5.6")>`
     },
     {
         tag: "assemblyversion",
-        expectedResult: `<Assembly: AssemblyVersion("4.5.6")>\n<Assembly: AssemblyFileVersion("1.2.3")>`
+        expectedResult: `<Assembly: AssemblyVersion("4.5.6")>\n<Assembly: AssemblyFileVersion("1.2.3")>\n` +
+            `<Assembly: AssemblyInformationalVersion("1.2.3")>`
     },
     {
         tag: "assemblyfileversion",
-        expectedResult: `<Assembly: AssemblyVersion("1.2.3")>\n<Assembly: AssemblyFileVersion("4.5.6")>`
+        expectedResult: `<Assembly: AssemblyVersion("1.2.3")>\n<Assembly: AssemblyFileVersion("4.5.6")>\n` +
+            `<Assembly: AssemblyInformationalVersion("1.2.3")>`
+    },
+    {
+        tag: "assemblyinformationalversion",
+        expectedResult: `<Assembly: AssemblyVersion("1.2.3")>\n<Assembly: AssemblyFileVersion("1.2.3")>\n` +
+            `<Assembly: AssemblyInformationalVersion("4.5.6")>`
     }]
 };
 

--- a/src/tests/plugins-tests/csproj-plugin-test.ts
+++ b/src/tests/plugins-tests/csproj-plugin-test.ts
@@ -5,38 +5,51 @@ const csProjPluginTest: PluginTest =
 {
     plugin: new CsProjPlugin(),
     input: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-        `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n<FileVersion>1.2.3</FileVersion>\n` +
+        `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+        `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
         `</PropertyGroup>\n</Project>`,
     newVersion: "4.5.6",
     tagTests:
     [{
         tag: "*",
         expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>4.5.6</Version>\n<VersionPrefix>4.5.6</VersionPrefix>\n<AssemblyVersion>4.5.6</AssemblyVersion>\n<FileVersion>4.5.6</FileVersion>\n` +
+            `<Version>4.5.6</Version>\n<VersionPrefix>4.5.6</VersionPrefix>\n<AssemblyVersion>4.5.6</AssemblyVersion>\n` +
+            `<FileVersion>4.5.6</FileVersion>\n<InformationalVersion>4.5.6</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     },
     {
         tag: "version",
         expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>4.5.6</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n<FileVersion>1.2.3</FileVersion>\n` +
+            `<Version>4.5.6</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+            `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     },
     {
         tag: "versionprefix",
         expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>1.2.3</Version>\n<VersionPrefix>4.5.6</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n<FileVersion>1.2.3</FileVersion>\n` +
+            `<Version>1.2.3</Version>\n<VersionPrefix>4.5.6</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+            `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     },
     {
         tag: "assemblyversion",
         expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>4.5.6</AssemblyVersion>\n<FileVersion>1.2.3</FileVersion>\n` +
+            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>4.5.6</AssemblyVersion>\n` +
+            `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     },
     {
         tag: "fileversion",
         expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n<FileVersion>4.5.6</FileVersion>\n` +
+            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+            `<FileVersion>4.5.6</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
+            `</PropertyGroup>\n</Project>`
+    },
+    {
+        tag: "informationalversion",
+        expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
+            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+            `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>4.5.6</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     }]
 };

--- a/src/tests/plugins-tests/fsproj-plugin-test.ts
+++ b/src/tests/plugins-tests/fsproj-plugin-test.ts
@@ -5,38 +5,51 @@ const fsProjPluginTest: PluginTest =
 {
     plugin: new FsProjPlugin(),
     input: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-        `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n<FileVersion>1.2.3</FileVersion>\n` +
+        `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+        `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
         `</PropertyGroup>\n</Project>`,
     newVersion: "4.5.6",
     tagTests:
     [{
         tag: "*",
         expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>4.5.6</Version>\n<VersionPrefix>4.5.6</VersionPrefix>\n<AssemblyVersion>4.5.6</AssemblyVersion>\n<FileVersion>4.5.6</FileVersion>\n` +
+            `<Version>4.5.6</Version>\n<VersionPrefix>4.5.6</VersionPrefix>\n<AssemblyVersion>4.5.6</AssemblyVersion>\n` +
+            `<FileVersion>4.5.6</FileVersion>\n<InformationalVersion>4.5.6</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     },
     {
         tag: "version",
         expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>4.5.6</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n<FileVersion>1.2.3</FileVersion>\n` +
+            `<Version>4.5.6</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+            `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     },
     {
         tag: "versionprefix",
         expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>1.2.3</Version>\n<VersionPrefix>4.5.6</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n<FileVersion>1.2.3</FileVersion>\n` +
+            `<Version>1.2.3</Version>\n<VersionPrefix>4.5.6</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+            `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     },
     {
         tag: "assemblyversion",
         expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>4.5.6</AssemblyVersion>\n<FileVersion>1.2.3</FileVersion>\n` +
+            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>4.5.6</AssemblyVersion>\n` +
+            `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     },
     {
         tag: "fileversion",
         expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n<FileVersion>4.5.6</FileVersion>\n` +
+            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+            `<FileVersion>4.5.6</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
+            `</PropertyGroup>\n</Project>`
+    },
+    {
+        tag: "informationalversion",
+        expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
+            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+            `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>4.5.6</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     }]
 };

--- a/src/tests/plugins-tests/props-plugin-test.ts
+++ b/src/tests/plugins-tests/props-plugin-test.ts
@@ -4,39 +4,52 @@ import PropsPlugin from "../../plugins/props-plugin";
 const propsPluginTest: PluginTest =
 {
     plugin: new PropsPlugin(),
-    input: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-        `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n<FileVersion>1.2.3</FileVersion>\n` +
+    input: `<Project>\n<PropertyGroup>\n` +
+        `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+        `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
         `</PropertyGroup>\n</Project>`,
     newVersion: "4.5.6",
     tagTests:
     [{
         tag: "*",
-        expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>4.5.6</Version>\n<VersionPrefix>4.5.6</VersionPrefix>\n<AssemblyVersion>4.5.6</AssemblyVersion>\n<FileVersion>4.5.6</FileVersion>\n` +
+        expectedResult: `<Project>\n<PropertyGroup>\n` +
+            `<Version>4.5.6</Version>\n<VersionPrefix>4.5.6</VersionPrefix>\n<AssemblyVersion>4.5.6</AssemblyVersion>\n` +
+            `<FileVersion>4.5.6</FileVersion>\n<InformationalVersion>4.5.6</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     },
     {
         tag: "version",
-        expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>4.5.6</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n<FileVersion>1.2.3</FileVersion>\n` +
+        expectedResult: `<Project>\n<PropertyGroup>\n` +
+            `<Version>4.5.6</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+            `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     },
     {
         tag: "versionprefix",
-        expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>1.2.3</Version>\n<VersionPrefix>4.5.6</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n<FileVersion>1.2.3</FileVersion>\n` +
+        expectedResult: `<Project>\n<PropertyGroup>\n` +
+            `<Version>1.2.3</Version>\n<VersionPrefix>4.5.6</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+            `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     },
     {
         tag: "assemblyversion",
-        expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>4.5.6</AssemblyVersion>\n<FileVersion>1.2.3</FileVersion>\n` +
+        expectedResult: `<Project>\n<PropertyGroup>\n` +
+            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>4.5.6</AssemblyVersion>\n` +
+            `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     },
     {
         tag: "fileversion",
-        expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n<FileVersion>4.5.6</FileVersion>\n` +
+        expectedResult: `<Project>\n<PropertyGroup>\n` +
+            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+            `<FileVersion>4.5.6</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
+            `</PropertyGroup>\n</Project>`
+    },
+    {
+        tag: "informationalversion",
+        expectedResult: `<Project>\n<PropertyGroup>\n` +
+            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+            `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>4.5.6</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     }]
 };

--- a/src/tests/plugins-tests/vbproj-plugin-test.ts
+++ b/src/tests/plugins-tests/vbproj-plugin-test.ts
@@ -5,38 +5,51 @@ const vbProjPluginTest: PluginTest =
 {
     plugin: new VbProjPlugin(),
     input: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-        `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n<FileVersion>1.2.3</FileVersion>\n` +
+        `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+        `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
         `</PropertyGroup>\n</Project>`,
     newVersion: "4.5.6",
     tagTests:
     [{
         tag: "*",
         expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>4.5.6</Version>\n<VersionPrefix>4.5.6</VersionPrefix>\n<AssemblyVersion>4.5.6</AssemblyVersion>\n<FileVersion>4.5.6</FileVersion>\n` +
+            `<Version>4.5.6</Version>\n<VersionPrefix>4.5.6</VersionPrefix>\n<AssemblyVersion>4.5.6</AssemblyVersion>\n` +
+            `<FileVersion>4.5.6</FileVersion>\n<InformationalVersion>4.5.6</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     },
     {
         tag: "version",
         expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>4.5.6</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n<FileVersion>1.2.3</FileVersion>\n` +
+            `<Version>4.5.6</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+            `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     },
     {
         tag: "versionprefix",
         expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>1.2.3</Version>\n<VersionPrefix>4.5.6</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n<FileVersion>1.2.3</FileVersion>\n` +
+            `<Version>1.2.3</Version>\n<VersionPrefix>4.5.6</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+            `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     },
     {
         tag: "assemblyversion",
         expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>4.5.6</AssemblyVersion>\n<FileVersion>1.2.3</FileVersion>\n` +
+            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>4.5.6</AssemblyVersion>\n` +
+            `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     },
     {
         tag: "fileversion",
         expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
-            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n<FileVersion>4.5.6</FileVersion>\n` +
+            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+            `<FileVersion>4.5.6</FileVersion>\n<InformationalVersion>1.2.3</InformationalVersion>` +
+            `</PropertyGroup>\n</Project>`
+    },
+    {
+        tag: "informationalversion",
+        expectedResult: `<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup>\n` +
+            `<Version>1.2.3</Version>\n<VersionPrefix>1.2.3</VersionPrefix>\n<AssemblyVersion>1.2.3</AssemblyVersion>\n` +
+            `<FileVersion>1.2.3</FileVersion>\n<InformationalVersion>4.5.6</InformationalVersion>` +
             `</PropertyGroup>\n</Project>`
     }]
 };

--- a/test-files/all-files-test/expected-results/Test.cpp
+++ b/test-files/all-files-test/expected-results/Test.cpp
@@ -1,2 +1,3 @@
 [assembly:AssemblyVersionAttribute(L"4.5.6")];
 [assembly:AssemblyFileVersionAttribute(L"4.5.6")]
+[assembly:AssemblyInformationalVersionAttribute(L"4.5.6")]

--- a/test-files/all-files-test/expected-results/Test.cs
+++ b/test-files/all-files-test/expected-results/Test.cs
@@ -1,2 +1,3 @@
 [assembly: AssemblyVersion("4.5.6")]
 [assembly: AssemblyFileVersion("4.5.6")]
+[assembly: AssemblyInformationalVersion("4.5.6")]

--- a/test-files/all-files-test/expected-results/Test.csproj
+++ b/test-files/all-files-test/expected-results/Test.csproj
@@ -4,5 +4,6 @@
         <VersionPrefix>4.5.6</VersionPrefix>
         <AssemblyVersion>4.5.6</AssemblyVersion>
         <FileVersion>4.5.6</FileVersion>
+        <InformationalVersion>4.5.6</InformationalVersion>
     </PropertyGroup>
 </Project>

--- a/test-files/all-files-test/expected-results/Test.fs
+++ b/test-files/all-files-test/expected-results/Test.fs
@@ -1,3 +1,4 @@
 [<assembly: AssemblyVersion("4.5.6")>]
 [<assembly: AssemblyFileVersion("4.5.6")>]
+[<assembly: AssemblyInformationalVersion("4.5.6")>]
 do()

--- a/test-files/all-files-test/expected-results/Test.fsproj
+++ b/test-files/all-files-test/expected-results/Test.fsproj
@@ -4,5 +4,6 @@
         <VersionPrefix>4.5.6</VersionPrefix>
         <AssemblyVersion>4.5.6</AssemblyVersion>
         <FileVersion>4.5.6</FileVersion>
+        <InformationalVersion>4.5.6</InformationalVersion>
     </PropertyGroup>
 </Project>

--- a/test-files/all-files-test/expected-results/Test.props
+++ b/test-files/all-files-test/expected-results/Test.props
@@ -4,5 +4,6 @@
         <VersionPrefix>4.5.6</VersionPrefix>
         <AssemblyVersion>4.5.6</AssemblyVersion>
         <FileVersion>4.5.6</FileVersion>
+        <InformationalVersion>4.5.6</InformationalVersion>
     </PropertyGroup>
 </Project>

--- a/test-files/all-files-test/expected-results/Test.vb
+++ b/test-files/all-files-test/expected-results/Test.vb
@@ -1,2 +1,3 @@
 <Assembly: AssemblyVersion("4.5.6")>
 <Assembly: AssemblyFileVersion("4.5.6")>
+<Assembly: AssemblyInformationalVersion("4.5.6")>

--- a/test-files/all-files-test/expected-results/Test.vbproj
+++ b/test-files/all-files-test/expected-results/Test.vbproj
@@ -4,5 +4,6 @@
         <VersionPrefix>4.5.6</VersionPrefix>
         <AssemblyVersion>4.5.6</AssemblyVersion>
         <FileVersion>4.5.6</FileVersion>
+        <InformationalVersion>4.5.6</InformationalVersion>
     </PropertyGroup>
 </Project>

--- a/test-files/all-files-test/input/Test.cpp
+++ b/test-files/all-files-test/input/Test.cpp
@@ -1,2 +1,3 @@
 [assembly:AssemblyVersionAttribute(L"1.2.3")];
 [assembly:AssemblyFileVersionAttribute(L"1.2.3")]
+[assembly:AssemblyInformationalVersionAttribute(L"1.2.3")]

--- a/test-files/all-files-test/input/Test.cs
+++ b/test-files/all-files-test/input/Test.cs
@@ -1,2 +1,3 @@
 [assembly: AssemblyVersion("1.2.3")]
 [assembly: AssemblyFileVersion("1.2.3")]
+[assembly: AssemblyInformationalVersion("1.2.3")]

--- a/test-files/all-files-test/input/Test.csproj
+++ b/test-files/all-files-test/input/Test.csproj
@@ -4,5 +4,6 @@
         <VersionPrefix>1.2.3</VersionPrefix>
         <AssemblyVersion>1.2.3</AssemblyVersion>
         <FileVersion>1.2.3</FileVersion>
+        <InformationalVersion>1.2.3</InformationalVersion>
     </PropertyGroup>
 </Project>

--- a/test-files/all-files-test/input/Test.fs
+++ b/test-files/all-files-test/input/Test.fs
@@ -1,3 +1,4 @@
 [<assembly: AssemblyVersion("1.2.3")>]
 [<assembly: AssemblyFileVersion("1.2.3")>]
+[<assembly: AssemblyInformationalVersion("1.2.3")>]
 do()

--- a/test-files/all-files-test/input/Test.fsproj
+++ b/test-files/all-files-test/input/Test.fsproj
@@ -4,5 +4,6 @@
         <VersionPrefix>1.2.3</VersionPrefix>
         <AssemblyVersion>1.2.3</AssemblyVersion>
         <FileVersion>1.2.3</FileVersion>
+        <InformationalVersion>1.2.3</InformationalVersion>
     </PropertyGroup>
 </Project>

--- a/test-files/all-files-test/input/Test.props
+++ b/test-files/all-files-test/input/Test.props
@@ -4,5 +4,6 @@
         <VersionPrefix>1.2.3</VersionPrefix>
         <AssemblyVersion>1.2.3</AssemblyVersion>
         <FileVersion>1.2.3</FileVersion>
+        <InformationalVersion>1.2.3</InformationalVersion>
     </PropertyGroup>
 </Project>

--- a/test-files/all-files-test/input/Test.vb
+++ b/test-files/all-files-test/input/Test.vb
@@ -1,2 +1,3 @@
 <Assembly: AssemblyVersion("1.2.3")>
 <Assembly: AssemblyFileVersion("1.2.3")>
+<Assembly: AssemblyInformationalVersion("1.2.3")>

--- a/test-files/all-files-test/input/Test.vbproj
+++ b/test-files/all-files-test/input/Test.vbproj
@@ -4,5 +4,6 @@
         <VersionPrefix>1.2.3</VersionPrefix>
         <AssemblyVersion>1.2.3</AssemblyVersion>
         <FileVersion>1.2.3</FileVersion>
+        <InformationalVersion>1.2.3</InformationalVersion>
     </PropertyGroup>
 </Project>

--- a/test-files/files-with-comments-test/expected-results/Test.cpp
+++ b/test-files/files-with-comments-test/expected-results/Test.cpp
@@ -1,4 +1,6 @@
 // [assembly:AssemblyVersionAttribute(L"1.2.3")];
 // [assembly:AssemblyFileVersionAttribute(L"1.2.3")]
+// [assembly:AssemblyInformationalVersionAttribute(L"1.2.3")]
 [assembly:AssemblyVersionAttribute(L"4.5.6")];
 [assembly:AssemblyFileVersionAttribute(L"4.5.6")]
+[assembly:AssemblyInformationalVersionAttribute(L"4.5.6")]

--- a/test-files/files-with-comments-test/expected-results/Test.cs
+++ b/test-files/files-with-comments-test/expected-results/Test.cs
@@ -1,4 +1,6 @@
 // [assembly: AssemblyVersion("1.2.3")]
 // [assembly: AssemblyFileVersion("1.2.3")]
+// [assembly: AssemblyInformationalVersion("1.2.3")]
 [assembly: AssemblyVersion("4.5.6")]
 [assembly: AssemblyFileVersion("4.5.6")]
+[assembly: AssemblyInformationalVersion("4.5.6")]

--- a/test-files/files-with-comments-test/expected-results/Test.fs
+++ b/test-files/files-with-comments-test/expected-results/Test.fs
@@ -1,5 +1,7 @@
 // [<assembly: AssemblyVersion("1.2.3")>]
 // [<assembly: AssemblyFileVersion("1.2.3")>]
+// [<assembly: AssemblyInformationalVersion("1.2.3")>]
 [<assembly: AssemblyVersion("4.5.6")>]
 [<assembly: AssemblyFileVersion("4.5.6")>]
+[<assembly: AssemblyInformationalVersion("4.5.6")>]
 do()

--- a/test-files/files-with-comments-test/expected-results/Test.vb
+++ b/test-files/files-with-comments-test/expected-results/Test.vb
@@ -1,4 +1,6 @@
 ' <Assembly: AssemblyVersion("1.2.3")>
 ' <Assembly: AssemblyFileVersion("1.2.3")>
+' <Assembly: AssemblyInformationalVersion("1.2.3")>
 <Assembly: AssemblyVersion("4.5.6")>
 <Assembly: AssemblyFileVersion("4.5.6")>
+<Assembly: AssemblyInformationalVersion("4.5.6")>

--- a/test-files/files-with-comments-test/input/Test.cpp
+++ b/test-files/files-with-comments-test/input/Test.cpp
@@ -1,4 +1,6 @@
 // [assembly:AssemblyVersionAttribute(L"1.2.3")];
 // [assembly:AssemblyFileVersionAttribute(L"1.2.3")]
+// [assembly:AssemblyInformationalVersionAttribute(L"1.2.3")]
 [assembly:AssemblyVersionAttribute(L"1.2.3")];
 [assembly:AssemblyFileVersionAttribute(L"1.2.3")]
+[assembly:AssemblyInformationalVersionAttribute(L"1.2.3")]

--- a/test-files/files-with-comments-test/input/Test.cs
+++ b/test-files/files-with-comments-test/input/Test.cs
@@ -1,4 +1,6 @@
 // [assembly: AssemblyVersion("1.2.3")]
 // [assembly: AssemblyFileVersion("1.2.3")]
+// [assembly: AssemblyInformationalVersion("1.2.3")]
 [assembly: AssemblyVersion("1.2.3")]
 [assembly: AssemblyFileVersion("1.2.3")]
+[assembly: AssemblyInformationalVersion("1.2.3")]

--- a/test-files/files-with-comments-test/input/Test.fs
+++ b/test-files/files-with-comments-test/input/Test.fs
@@ -1,5 +1,7 @@
 // [<assembly: AssemblyVersion("1.2.3")>]
 // [<assembly: AssemblyFileVersion("1.2.3")>]
+// [<assembly: AssemblyInformationalVersion("1.2.3")>]
 [<assembly: AssemblyVersion("1.2.3")>]
 [<assembly: AssemblyFileVersion("1.2.3")>]
+[<assembly: AssemblyInformationalVersion("1.2.3")>]
 do()

--- a/test-files/files-with-comments-test/input/Test.vb
+++ b/test-files/files-with-comments-test/input/Test.vb
@@ -1,4 +1,6 @@
 ' <Assembly: AssemblyVersion("1.2.3")>
 ' <Assembly: AssemblyFileVersion("1.2.3")>
+' <Assembly: AssemblyInformationalVersion("1.2.3")>
 <Assembly: AssemblyVersion("1.2.3")>
 <Assembly: AssemblyFileVersion("1.2.3")>
+<Assembly: AssemblyInformationalVersion("1.2.3")>

--- a/test-files/no-matching-files-test/input/Test.cs
+++ b/test-files/no-matching-files-test/input/Test.cs
@@ -1,2 +1,3 @@
 [assembly: AssemblyVersion("1.2.3")]
 [assembly: AssemblyFileVersion("1.2.3")]
+[assembly: AssemblyInformationalVersion("1.2.3")]

--- a/test-files/no-matching-files-test/input/Test.csproj
+++ b/test-files/no-matching-files-test/input/Test.csproj
@@ -4,5 +4,6 @@
         <VersionPrefix>1.2.3</VersionPrefix>
         <AssemblyVersion>1.2.3</AssemblyVersion>
         <FileVersion>1.2.3</FileVersion>
+        <InformationalVersion>1.2.3</InformationalVersion>
     </PropertyGroup>
 </Project>

--- a/test-files/single-file-test/input/Test.cs
+++ b/test-files/single-file-test/input/Test.cs
@@ -1,2 +1,3 @@
 [assembly: AssemblyVersion("4.5.6")]
 [assembly: AssemblyFileVersion("4.5.6")]
+[assembly: AssemblyInformationalVersion("4.5.6")]

--- a/test-files/single-file-test/input/Test.csproj
+++ b/test-files/single-file-test/input/Test.csproj
@@ -4,5 +4,6 @@
         <VersionPrefix>4.5.6</VersionPrefix>
         <AssemblyVersion>4.5.6</AssemblyVersion>
         <FileVersion>4.5.6</FileVersion>
+        <InformationalVersion>4.5.6</InformationalVersion>
     </PropertyGroup>
 </Project>

--- a/test-files/tag-filter-test/expected-results/Skip.props
+++ b/test-files/tag-filter-test/expected-results/Skip.props
@@ -2,5 +2,8 @@
     <PropertyGroup>
         <Version>1.2.3</Version>
         <VersionPrefix>1.2.3</VersionPrefix>
+        <AssemblyVersion>1.2.3</AssemblyVersion>
+        <FileVersion>1.2.3</FileVersion>
+        <InformationalVersion>1.2.3</InformationalVersion>
     </PropertyGroup>
 </Project>

--- a/test-files/tag-filter-test/expected-results/Test.cs
+++ b/test-files/tag-filter-test/expected-results/Test.cs
@@ -1,2 +1,3 @@
 [assembly: AssemblyVersion("4.5.6")]
 [assembly: AssemblyFileVersion("4.5.6")]
+[assembly: AssemblyInformationalVersion("4.5.6")]

--- a/test-files/tag-filter-test/expected-results/Test.csproj
+++ b/test-files/tag-filter-test/expected-results/Test.csproj
@@ -4,5 +4,6 @@
         <VersionPrefix>1.2.3</VersionPrefix>
         <AssemblyVersion>4.5.6</AssemblyVersion>
         <FileVersion>1.2.3</FileVersion>
+        <InformationalVersion>1.2.3</InformationalVersion>
     </PropertyGroup>
 </Project>

--- a/test-files/tag-filter-test/input/Skip.props
+++ b/test-files/tag-filter-test/input/Skip.props
@@ -2,5 +2,8 @@
     <PropertyGroup>
         <Version>1.2.3</Version>
         <VersionPrefix>1.2.3</VersionPrefix>
+        <AssemblyVersion>1.2.3</AssemblyVersion>
+        <FileVersion>1.2.3</FileVersion>
+        <InformationalVersion>1.2.3</InformationalVersion>
     </PropertyGroup>
 </Project>

--- a/test-files/tag-filter-test/input/Test.cs
+++ b/test-files/tag-filter-test/input/Test.cs
@@ -1,2 +1,3 @@
 [assembly: AssemblyVersion("1.2.3")]
 [assembly: AssemblyFileVersion("1.2.3")]
+[assembly: AssemblyInformationalVersion("1.2.3")]

--- a/test-files/tag-filter-test/input/Test.csproj
+++ b/test-files/tag-filter-test/input/Test.csproj
@@ -4,5 +4,6 @@
         <VersionPrefix>1.2.3</VersionPrefix>
         <AssemblyVersion>1.2.3</AssemblyVersion>
         <FileVersion>1.2.3</FileVersion>
+        <InformationalVersion>1.2.3</InformationalVersion>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
This pull request adds support for:
1. `<InformationalVersion>...</InformationalVersion>` tags for *.csproj*, *.vbproj*, *.fsproj*, and *.props* files.
2. `[assembly: AssemblyInformationalVersion("...")]` attributes for *.cs* files.
3. `<Assembly: AssemblyInformationalVersion("...")>` attributes for *.vb* files.
4. `[<assembly: AssemblyInformationalVersion("...")>]` attributes for *.fs* files.
5. `[assembly:AssemblyInformationalVersionAttribute(L"...")]` attributes for *.cpp* files.