### PR TITLE
Update to Node 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ jobs:
 
       - name: Set MyProject.csproj version
         id: update
-        uses: vers-one/dotnet-project-version-updater@v1.7
+        uses: vers-one/dotnet-project-version-updater@v1.8
         with:
           file: "src/MyProject.csproj"
           version: ${{ github.event.inputs.version }}
@@ -228,7 +228,7 @@ jobs:
 
       - name: Set project versions
         id: update
-        uses: vers-one/dotnet-project-version-updater@v1.7
+        uses: vers-one/dotnet-project-version-updater@v1.8
         with:
           file: |
             "**/*.csproj", "**/*.nuspec", "**/AssemblyInfo.cs"
@@ -272,7 +272,7 @@ jobs:
 
       - name: Bump build version
         id: bump
-        uses: vers-one/dotnet-project-version-updater@v1.7
+        uses: vers-one/dotnet-project-version-updater@v1.8
         with:
           file: "src/MyProject.csproj"
           version: bump-build

--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ outputs:
   newVersion:
     description: "Version set by the action during the update"
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dotnet-project-version-updater",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dotnet-project-version-updater",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-project-version-updater",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "A GitHub action to update or bump project versions. Supports .csproj, .props, .nuspec, and many other .NET file types.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Node.js 20 is [being deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) for GitHub Actions. This pull request updates the version of Node.js used by this action to 24.